### PR TITLE
Log details about not found handler factory

### DIFF
--- a/core/src/main/java/io/knotx/server/KnotxServerVerticle.java
+++ b/core/src/main/java/io/knotx/server/KnotxServerVerticle.java
@@ -15,9 +15,9 @@
  */
 package io.knotx.server;
 
+import io.knotx.server.api.handler.RoutingHandlerFactory;
 import io.knotx.server.configuration.KnotxServerOptions;
 import io.knotx.server.configuration.RoutingOperationOptions;
-import io.knotx.server.api.handler.RoutingHandlerFactory;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.SingleSource;
 import io.vertx.core.Context;
@@ -100,7 +100,13 @@ public class KnotxServerVerticle extends AbstractVerticle {
                     .addHandlerByOperationId(options.getOperationId(),
                         handlerFactory.create(vertx, routingHandlerOptions.getConfig()))
             )
-            .orElseThrow(IllegalStateException::new)
+            .orElseThrow(() -> {
+              LOGGER.error(
+                  "Handler factory [{}] not found in registered factories [{}], all options [{}]",
+                  routingHandlerOptions.getName(), handlerFactories, options);
+              return new IllegalStateException(
+                  "Can not find handler factory for [" + routingHandlerOptions.getName() + "]");
+            })
     );
   }
 


### PR DESCRIPTION
Adds logging when routing handler not found in registered factories.

## Description
Adds logging when routing handler not found in registered factories.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
