### PR TITLE
Knot.x Hystrics metrics enabled

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(group = "io.vertx", name = "vertx-web-api-service")
     implementation(group = "io.vertx", name = "vertx-web")
     implementation(group = "io.vertx", name = "vertx-web-client")
+    implementation(group = "io.vertx", name = "vertx-circuit-breaker")
 
     testImplementation(group = "io.vertx", name = "vertx-auth-jwt")
     testImplementation(group = "io.vertx", name = "vertx-auth-shiro")

--- a/core/docs/asciidoc/dataobjects.adoc
+++ b/core/docs/asciidoc/dataobjects.adoc
@@ -170,6 +170,9 @@ Set whether to display or not the exception on error pages
 |[[dropRequestOptions]]`@dropRequestOptions`|`link:dataobjects.html#DropRequestOptions[DropRequestOptions]`|+++
 Set the drop request options
 +++
+|[[enableHystrixMetrics]]`@enableHystrixMetrics`|`Boolean`|+++
+Set whether to setup or not hystrix metrics
++++
 |[[globalHandlers]]`@globalHandlers`|`Array of link:dataobjects.html#RoutingHandlerOptions[RoutingHandlerOptions]`|+++
 List of <code>RoutingHandlerOptions</code> containing handlers configurations which are initiated
  (loaded from classpath via <code>java.util.ServiceLoader</code>) during server setup and applied to

--- a/core/docs/asciidoc/dataobjects.adoc
+++ b/core/docs/asciidoc/dataobjects.adoc
@@ -152,6 +152,26 @@ Enabled/disables request dropping (backpressure) on heavy load. Default is true 
 +++
 |===
 
+[[HystrixMetricsOptions]]
+== HystrixMetricsOptions
+
+++++
+ Describes Knot.x Hystrix metrics options
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`@enabled`|`Boolean`|+++
+Enabled/disables Hystrix metrics exposed by Knot.x Server, by default - disabled.
++++
+|[[endpoint]]`@endpoint`|`String`|+++
+Sets Hystrix metrics endpoint under which it will expose the metrics. By default <code>/hystrix-metrics</code>
++++
+|===
+
 [[KnotxServerOptions]]
 == KnotxServerOptions
 
@@ -168,15 +188,15 @@ Enabled/disables request dropping (backpressure) on heavy load. Default is true 
 Set whether to display or not the exception on error pages
 +++
 |[[dropRequestOptions]]`@dropRequestOptions`|`link:dataobjects.html#DropRequestOptions[DropRequestOptions]`|+++
-Set the drop request options
-+++
-|[[enableHystrixMetrics]]`@enableHystrixMetrics`|`Boolean`|+++
-Set whether to setup or not hystrix metrics
+Set the drop request options (see <code>DropRequestOptions</code>)
 +++
 |[[globalHandlers]]`@globalHandlers`|`Array of link:dataobjects.html#RoutingHandlerOptions[RoutingHandlerOptions]`|+++
 List of <code>RoutingHandlerOptions</code> containing handlers configurations which are initiated
  (loaded from classpath via <code>java.util.ServiceLoader</code>) during server setup and applied to
  each route.
++++
+|[[hystrixMetricsOptions]]`@hystrixMetricsOptions`|`link:dataobjects.html#HystrixMetricsOptions[HystrixMetricsOptions]`|+++
+Set the Hystrix Metrics options (see <code>HystrixMetricsOptions</code>).
 +++
 |[[routingOperations]]`@routingOperations`|`Array of link:dataobjects.html#RoutingOperationOptions[RoutingOperationOptions]`|+++
 Set list of <code>RoutingOperationOptions</code>.

--- a/core/src/main/java/io/knotx/server/KnotxServerVerticle.java
+++ b/core/src/main/java/io/knotx/server/KnotxServerVerticle.java
@@ -15,6 +15,7 @@
  */
 package io.knotx.server;
 
+import io.knotx.server.configuration.HystrixMetricsOptions;
 import io.knotx.server.configuration.KnotxServerOptions;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -76,7 +77,10 @@ public class KnotxServerVerticle extends AbstractVerticle {
   }
 
   private Router metrics(Router router) {
-    router.get("/hystrix-metrics").handler(HystrixMetricHandler.create(vertx));
+    HystrixMetricsOptions hystrixMetricsOptions = options.getHystrixMetricsOptions();
+    if (hystrixMetricsOptions.isEnabled()) {
+      router.get(hystrixMetricsOptions.getEndpoint()).handler(HystrixMetricHandler.create(vertx));
+    }
     return router;
   }
 

--- a/core/src/main/java/io/knotx/server/KnotxServerVerticle.java
+++ b/core/src/main/java/io/knotx/server/KnotxServerVerticle.java
@@ -60,7 +60,7 @@ public class KnotxServerVerticle extends AbstractVerticle {
         .doOnSuccess(routesProvider::configureRouting)
         .doOnSuccess(OpenAPI3RouterFactory::mountServicesFromExtensions)
         .map(OpenAPI3RouterFactory::getRouter)
-        .map(this::metrics)
+        .doOnSuccess(this::addHystrixMetrics)
         .doOnSuccess(this::logRouterRoutes)
         .flatMap(httpServerProvider::configureHttpServer)
         .subscribe(
@@ -76,12 +76,11 @@ public class KnotxServerVerticle extends AbstractVerticle {
         );
   }
 
-  private Router metrics(Router router) {
+  private void addHystrixMetrics(Router router) {
     HystrixMetricsOptions hystrixMetricsOptions = options.getHystrixMetricsOptions();
     if (hystrixMetricsOptions.isEnabled()) {
       router.get(hystrixMetricsOptions.getEndpoint()).handler(HystrixMetricHandler.create(vertx));
     }
-    return router;
   }
 
   private void logRouterRoutes(Router router) {

--- a/core/src/main/java/io/knotx/server/configuration/HystrixMetricsOptions.java
+++ b/core/src/main/java/io/knotx/server/configuration/HystrixMetricsOptions.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.server.configuration;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Describes Knot.x Hystrix metrics options
+ */
+@DataObject(generateConverter = true, publicConverter = false)
+public class HystrixMetricsOptions {
+
+  /**
+   * Default flag whether a metrics should be enabled or not = false
+   */
+  private static final boolean DEFAULT_ENABLE_METRICS = false;
+
+  /**
+   * Default endpoint where metrics will be enabled.
+   */
+  private static final String DEFAULT_METRICS_ENDPOINT = "/hystrix-metrics";
+
+  private boolean enabled;
+  private String endpoint;
+
+  /**
+   * Default constructor
+   */
+  public HystrixMetricsOptions() {
+    init();
+  }
+
+  /**
+   * Create an settings from JSON
+   *
+   * @param json the JSON
+   */
+  public HystrixMetricsOptions(JsonObject json) {
+    init();
+    HystrixMetricsOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    HystrixMetricsOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  private void init() {
+    enabled = DEFAULT_ENABLE_METRICS;
+    endpoint = DEFAULT_METRICS_ENDPOINT;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Enabled/disables Hystrix metrics exposed by Knot.x Server, by default - disabled.
+   *
+   * @param enabled true - metrics enabled, false if disabled
+   * @return reference to this, so the API can be used fluently
+   */
+  public HystrixMetricsOptions setEnabled(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  /**
+   * Sets Hystrix metrics endpoint under which it will expose the metrics. By default {@code
+   * /hystrix-metrics}
+   *
+   * @param endpoint url under which metrics are provided
+   * @return reference to this, so the API can be used fluently
+   */
+  public HystrixMetricsOptions setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "HystrixMetricsOptions{" +
+        "enabled=" + enabled +
+        ", endpoint='" + endpoint + '\'' +
+        '}';
+  }
+}

--- a/core/src/main/java/io/knotx/server/configuration/KnotxServerOptions.java
+++ b/core/src/main/java/io/knotx/server/configuration/KnotxServerOptions.java
@@ -35,8 +35,10 @@ public class KnotxServerOptions {
    * Default flag if to show the exceptions on error pages = false
    */
   private static final boolean DEFAULT_DISPLAY_EXCEPTIONS = false;
+  private static final boolean DEFAULT_HYSTRIX_METRICS = false;
 
   private boolean displayExceptionDetails;
+  private boolean enableHystrixMetrics;
   private HttpServerOptions serverOptions;
   private String routingSpecificationLocation;
   private List<RoutingHandlerOptions> globalHandlers;
@@ -58,6 +60,7 @@ public class KnotxServerOptions {
    */
   public KnotxServerOptions(KnotxServerOptions other) {
     this.displayExceptionDetails = other.displayExceptionDetails;
+    this.enableHystrixMetrics = other.enableHystrixMetrics;
     this.serverOptions = new HttpServerOptions(other.serverOptions);
     this.routingSpecificationLocation = other.routingSpecificationLocation;
     this.globalHandlers = new ArrayList<>(other.globalHandlers);
@@ -92,6 +95,7 @@ public class KnotxServerOptions {
 
   private void init() {
     displayExceptionDetails = DEFAULT_DISPLAY_EXCEPTIONS;
+    enableHystrixMetrics = DEFAULT_HYSTRIX_METRICS;
     globalHandlers = new ArrayList<>();
     securityHandlers = new ArrayList<>();
     serverOptions = new HttpServerOptions();
@@ -113,6 +117,24 @@ public class KnotxServerOptions {
    */
   public KnotxServerOptions setDisplayExceptionDetails(boolean displayExceptionDetails) {
     this.displayExceptionDetails = displayExceptionDetails;
+    return this;
+  }
+
+  /**
+   * @return whether to setup or not hystrix metrics
+   */
+  public boolean isEnableHystrixMetrics() {
+    return enableHystrixMetrics;
+  }
+
+  /**
+   * Set whether to setup or not hystrix metrics
+   *
+   * @param enableHystrixMetrics expose hystrics metrics if true
+   * @return reference to this, so the API can be used fluently
+   */
+  public KnotxServerOptions setEnableHystrixMetrics(boolean enableHystrixMetrics) {
+    this.enableHystrixMetrics = enableHystrixMetrics;
     return this;
   }
 

--- a/core/src/main/java/io/knotx/server/configuration/KnotxServerOptions.java
+++ b/core/src/main/java/io/knotx/server/configuration/KnotxServerOptions.java
@@ -35,16 +35,15 @@ public class KnotxServerOptions {
    * Default flag if to show the exceptions on error pages = false
    */
   private static final boolean DEFAULT_DISPLAY_EXCEPTIONS = false;
-  private static final boolean DEFAULT_HYSTRIX_METRICS = false;
 
   private boolean displayExceptionDetails;
-  private boolean enableHystrixMetrics;
   private HttpServerOptions serverOptions;
   private String routingSpecificationLocation;
   private List<RoutingHandlerOptions> globalHandlers;
   private List<AuthHandlerOptions> securityHandlers;
   private List<RoutingOperationOptions> routingOperations;
   private DropRequestOptions dropRequestOptions;
+  private HystrixMetricsOptions hystrixMetricsOptions;
 
   /**
    * Default constructor
@@ -60,13 +59,13 @@ public class KnotxServerOptions {
    */
   public KnotxServerOptions(KnotxServerOptions other) {
     this.displayExceptionDetails = other.displayExceptionDetails;
-    this.enableHystrixMetrics = other.enableHystrixMetrics;
     this.serverOptions = new HttpServerOptions(other.serverOptions);
     this.routingSpecificationLocation = other.routingSpecificationLocation;
     this.globalHandlers = new ArrayList<>(other.globalHandlers);
     this.securityHandlers = new ArrayList<>(other.securityHandlers);
     this.routingOperations = new ArrayList<>(other.routingOperations);
     this.dropRequestOptions = other.dropRequestOptions;
+    this.hystrixMetricsOptions = other.hystrixMetricsOptions;
   }
 
   /**
@@ -95,11 +94,11 @@ public class KnotxServerOptions {
 
   private void init() {
     displayExceptionDetails = DEFAULT_DISPLAY_EXCEPTIONS;
-    enableHystrixMetrics = DEFAULT_HYSTRIX_METRICS;
     globalHandlers = new ArrayList<>();
     securityHandlers = new ArrayList<>();
     serverOptions = new HttpServerOptions();
     dropRequestOptions = new DropRequestOptions();
+    hystrixMetricsOptions = new HystrixMetricsOptions();
   }
 
   /**
@@ -117,24 +116,6 @@ public class KnotxServerOptions {
    */
   public KnotxServerOptions setDisplayExceptionDetails(boolean displayExceptionDetails) {
     this.displayExceptionDetails = displayExceptionDetails;
-    return this;
-  }
-
-  /**
-   * @return whether to setup or not hystrix metrics
-   */
-  public boolean isEnableHystrixMetrics() {
-    return enableHystrixMetrics;
-  }
-
-  /**
-   * Set whether to setup or not hystrix metrics
-   *
-   * @param enableHystrixMetrics expose hystrics metrics if true
-   * @return reference to this, so the API can be used fluently
-   */
-  public KnotxServerOptions setEnableHystrixMetrics(boolean enableHystrixMetrics) {
-    this.enableHystrixMetrics = enableHystrixMetrics;
     return this;
   }
 
@@ -251,7 +232,7 @@ public class KnotxServerOptions {
   }
 
   /**
-   * Set the drop request options
+   * Set the drop request options (see {@code DropRequestOptions})
    *
    * @param dropRequestOptions a {@code DropRequestOptions} configuration
    * @return reference to this, so the API can be used fluently
@@ -261,4 +242,32 @@ public class KnotxServerOptions {
     return this;
   }
 
+  public HystrixMetricsOptions getHystrixMetricsOptions() {
+    return hystrixMetricsOptions;
+  }
+
+  /**
+   * Set the Hystrix Metrics options (see {@code HystrixMetricsOptions}).
+   *
+   * @param hystrixMetricsOptions a {@code HystrixMetricsOptions} configuration
+   * @return to this, so the API can be used fluently
+   */
+  public KnotxServerOptions setHystrixMetricsOptions(HystrixMetricsOptions hystrixMetricsOptions) {
+    this.hystrixMetricsOptions = hystrixMetricsOptions;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "KnotxServerOptions{" +
+        "displayExceptionDetails=" + displayExceptionDetails +
+        ", serverOptions=" + serverOptions +
+        ", routingSpecificationLocation='" + routingSpecificationLocation + '\'' +
+        ", globalHandlers=" + globalHandlers +
+        ", securityHandlers=" + securityHandlers +
+        ", routingOperations=" + routingOperations +
+        ", dropRequestOptions=" + dropRequestOptions +
+        ", hystrixMetricsOptions=" + hystrixMetricsOptions +
+        '}';
+  }
 }


### PR DESCRIPTION
Setup Hystrix metrics in Knot.x Server. 

## Description
It allows to expose circuit breakers metrics and visualize them in Hystrix dashboard.

## Motivation and Context
Improve Knot.x monitoring.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
Default is false. You can set:
```
    enableHystrixMetrics = true
```
to setup Hystrics metrics handler in Knot.x Server router.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
