### PR TITLE
[#41]KnotxServer response configuration - wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-server-http` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-46](https://github.com/Knotx/knotx-server-http/pull/46) - KnotxServer response configuration - wildcards [41](https://github.com/Knotx/knotx-server-http/issues/41)
 
 ## 2.1.0
 - [PR-35](https://github.com/Knotx/knotx-server-http/pull/35) - Vert.x upgrade to 3.8.1. Cookie Handler was deprecated: cookies are enabled by default and `cookieHandler` handler is not required anymore.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(platform("io.knotx:knotx-dependencies:${project.version}"))
 
     api(project(":knotx-server-http-api"))
+    implementation("io.knotx:knotx-commons:${project.version}")
     implementation(group = "io.vertx", name = "vertx-core")
     implementation(group = "io.vertx", name = "vertx-service-proxy")
     implementation(group = "io.vertx", name = "vertx-rx-java2")

--- a/core/src/main/java/io/knotx/server/handler/http/response/writer/ServerResponse.java
+++ b/core/src/main/java/io/knotx/server/handler/http/response/writer/ServerResponse.java
@@ -18,6 +18,7 @@ package io.knotx.server.handler.http.response.writer;
 import java.util.Optional;
 import java.util.Set;
 
+import io.knotx.commons.http.request.AllowedHeadersFilter;
 import io.knotx.server.api.context.ClientResponse;
 import io.knotx.server.api.context.RequestContext;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -81,7 +82,7 @@ class ServerResponse {
       clientResponse.getHeaders()
           .names()
           .stream()
-          .filter(header -> headerFilter(allowedResponseHeaders, header))
+          .filter(AllowedHeadersFilter.CaseInsensitive.create(allowedResponseHeaders))
           .forEach(
               name ->
                   clientResponse.getHeaders()
@@ -104,10 +105,6 @@ class ServerResponse {
   private static boolean isOk(RequestContext requestContext) {
     return !requestContext.getStatus()
         .isFailed();
-  }
-
-  private Boolean headerFilter(Set<String> allowedResponseHeaders, String name) {
-    return allowedResponseHeaders.contains(name.toLowerCase());
   }
 
 }

--- a/core/src/test/java/io/knotx/server/handler/http/response/writer/ServerResponseTest.java
+++ b/core/src/test/java/io/knotx/server/handler/http/response/writer/ServerResponseTest.java
@@ -41,6 +41,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ServerResponseTest {
 
   private static final Set<String> DEFAULT_ALLOWED_HEADERS = Collections.singleton("test");
+  private static final Set<String> WILDCARD_ALLOWED_HEADERS = Collections.singleton(".*");
+  private static final Set<String> WILDCARDED_ALLOWED_HEADERS = Collections.singleton("te.*");
 
   @Mock
   private HttpServerResponse httpResponse;
@@ -175,4 +177,48 @@ class ServerResponseTest {
     assertEquals(1, headersMultiMap.size());
     assertEquals(headersMultiMap.get("test"), "testValue");
   }
+
+  @Test
+  @DisplayName("Expect headers filtered by wildcarded allowed headers out context ok")
+  void checkWildcardedAllowedHeaders() {
+    //given
+    when(status.isFailed()).thenReturn(false);
+    when(httpResponse.headers()).thenReturn(headersMultiMap);
+    when(clientResponse.getStatusCode()).thenReturn(HttpResponseStatus.OK.code());
+    final MultiMap headers = MultiMap.caseInsensitiveMultiMap()
+        .add("test", "testValue")
+        .add("notAllowed", "value")
+        .add("shouldBeFilteredOut", "value");
+    when(clientResponse.getHeaders()).thenReturn(headers);
+
+    //when
+    new ServerResponse(requestContext).end(httpResponse, WILDCARDED_ALLOWED_HEADERS);
+
+    //then
+    assertEquals(1, headersMultiMap.size());
+    assertEquals(headersMultiMap.get("test"), "testValue");
+  }
+
+  @Test
+  @DisplayName("Expect headers filtered by wildcard sign out context ok")
+  void checkWildcardSignHeadersFiltered() {
+    //given
+    when(status.isFailed()).thenReturn(false);
+    when(httpResponse.headers()).thenReturn(headersMultiMap);
+    when(clientResponse.getStatusCode()).thenReturn(HttpResponseStatus.OK.code());
+    final MultiMap headers = MultiMap.caseInsensitiveMultiMap()
+        .add("test", "testValue")
+        .add("notAllowed", "value")
+        .add("shouldBeFilteredOut", "value");
+    when(clientResponse.getHeaders()).thenReturn(headers);
+
+    //when
+    new ServerResponse(requestContext).end(httpResponse, WILDCARD_ALLOWED_HEADERS);
+
+    //then
+    assertEquals(3, headersMultiMap.size());
+    assertEquals(headersMultiMap.get("test"), "testValue");
+  }
+
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
KnotxServer response configuration - wildcards

## Description
<!--- Describe your changes in detail -->
Adds possibility to use wildcards in allowed headers configuration (also see [knotx-server-http#41](https://github.com/Knotx/knotx-server-http/issues/41)), test for wildcards

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[#41](https://github.com/Knotx/knotx-server-http/issues/41)

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
