### PR TITLE
Knotx/knotx-fragments#73 Placeholder resolution with disabled encoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-server-http` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-53](https://github.com/Knotx/knotx-server-http/pull/53) - Enable resolving placeholders without encoding.
 - [PR-46](https://github.com/Knotx/knotx-server-http/pull/46) - KnotxServer response configuration - wildcards [41](https://github.com/Knotx/knotx-server-http/issues/41)
 
 ## 2.1.0

--- a/common/placeholders/README.md
+++ b/common/placeholders/README.md
@@ -25,6 +25,8 @@ This module contains client request placeholders substitutors.
     }
     ```
 
-All placeholders are always substituted with encoded values according to the RFC standard. However, there are two exceptions:
+`PlaceholdersResolver` provides two methods for performing substitution: `resolve` which performs a direct substitution, and `resolveAndEncode` which also performs encoding.
+
+When calling `resolveAndEncode`, all placeholders are substituted with encoded values according to the RFC standard. However, there are two exceptions:
 - Space character is substituted by `%20` instead of `+`.
 - Slash character `/` remains as it is.


### PR DESCRIPTION
Provide a way to substitute values without escaping.

## Description
This change is required to enable interpolating not only URL in HTTP request, but also body. In this case, it should not be escaped. This PR enables skipping the escaping step.

## Motivation and Context
Knotx/knotx-fragments#73

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
