### PR TITLE
Fixed invalid openapi spec

### DIFF
--- a/core/src/test/resources/params-validation/openapi.yaml
+++ b/core/src/test/resources/params-validation/openapi.yaml
@@ -61,14 +61,14 @@ paths:
         - name: q
           in: path
           description: query pharse
-          required: false
+          required: true
           style: form
           schema:
             type: string
         - name: limit
           in: path
           description: maximum number of results to return
-          required: false
+          required: true
           schema:
             type: integer
             format: int32


### PR DESCRIPTION
## Description
Fixed invalid OpenAPI spec for the `path` parameters. According to the docs:
- https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameterObject, `required` 
> If the parameter location is "path", this property is REQUIRED and its value MUST be true.

## Motivation and Context
Unit tests from `KnotxServerParamsValidationTest` failed because of the invalid openapi config.
It looks that that validation libs were updated in https://github.com/vert-x3/vertx-web/pull/1708 and after upgrade to Vert.x 3.9.4 the issue was validated so the tests with invalid specs failed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
